### PR TITLE
Enhancements to scroll to hash

### DIFF
--- a/ScrollToHashElement.js
+++ b/ScrollToHashElement.js
@@ -1,33 +1,28 @@
-import { useMemo, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLayoutEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const ScrollToHashElement = () => {
-  let location = useLocation();
+  const location = useLocation();
 
-  let hashElement = useMemo(() => {
-    let hash = location.hash;
+  useLayoutEffect(() => {
+    const { hash } = location;
+
     const removeHashCharacter = (str) => {
       const result = str.slice(1);
       return result;
     };
 
     if (hash) {
-      let element = document.getElementById(removeHashCharacter(hash));
-      return element;
-    } else {
-      return null;
+      const element = document.getElementById(removeHashCharacter(hash));
+
+      if (element) {
+        element.scrollIntoView({
+          behavior: 'smooth',
+          inline: 'nearest',
+        });
+      }
     }
   }, [location]);
-
-  useEffect(() => {
-    if (hashElement) {
-      hashElement.scrollIntoView({
-        behavior: "smooth",
-        // block: "end",
-        inline: "nearest",
-      });
-    }
-  }, [hashElement]);
 
   return null;
 };


### PR DESCRIPTION
This change adds two main enhancements to scroll to hash 

1. When current page/route is different from where the hash is located. 
2. It also ensures scroll to hash is only run once the component is rendered using useLayoutEffect() (edge cases where document.getElementById() errors out because page has not rendered yet).
