### PR TITLE
Tweaks to fix React/TypeScript problems

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,8 @@ import { useLayoutEffect, useState, useEffect, useRef } from "react";
 
 
 interface ScrollToHashElementProps {
+  /** On first run do we jump or scroll? */
+  initialBehavior?: ScrollBehavior;
   behavior?: ScrollBehavior;
   inline?: ScrollLogicalPosition;
   block?: ScrollLogicalPosition;
@@ -9,6 +11,7 @@ interface ScrollToHashElementProps {
 
 const ScrollToHashElement = ({
   behavior = "auto",
+  initialBehavior = "auto",
   inline = "nearest",
   block = "start",
 }: ScrollToHashElementProps):null => {
@@ -16,6 +19,10 @@ const ScrollToHashElement = ({
   const [count, setCount] = useState(0);
   const originalListeners = useRef<{[key:string]: Function}>({})
   
+  // We need to know if this is the first run. If it is, we can do an instant jump, no scrolling.
+  const [firstRun, setFirstRun] = useState(true);
+  useEffect(() => setFirstRun(false), [])
+
 
   useEffect(() => {
   
@@ -79,13 +86,13 @@ const ScrollToHashElement = ({
       if (element) {
         // console.log(`scrollIntoView ${hash} behavior: ${behavior}, inline: ${inline}, block: ${block}`);
         element.scrollIntoView({
-          behavior: behavior,
+          behavior: firstRun ? initialBehavior : behavior,
           inline: inline,
           block: block,
         });
       }
     }
-  }, [hash, count]);
+  }, [hash, count, firstRun]);
 
   return null;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ const ScrollToHashElement = ({
   behavior = "auto",
   inline = "nearest",
   block = "start",
-}: ScrollToHashElementProps) => {
+}: ScrollToHashElementProps):null => {
   const [hash, setHash] = useState(window.location.hash);
 
   const originalPushState = window.history.pushState;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,8 @@ const ScrollToHashElement = ({
   block = "start",
 }: ScrollToHashElementProps):null => {
   const [hash, setHash] = useState(window.location.hash);
-
+  const [count, setCount] = useState(0);
+  
   const originalPushState = window.history.pushState;
   const originalReplaceState = window.history.replaceState;
 
@@ -39,6 +40,9 @@ const ScrollToHashElement = ({
     const handleLocationChange = () => {
       setHash(window.location.hash);
 
+      // We increment count just so the layout effect will run if the hash is the same.
+      // Otherwise the user might click a hashlink a second time and it won't go anywhere.
+      setCount(count=>count+1)
     };
 
     window.addEventListener('locationchange', handleLocationChange);
@@ -69,7 +73,7 @@ const ScrollToHashElement = ({
         });
       }
     }
-  }, [hash]);
+  }, [hash, count]);
 
   return null;
 };


### PR DESCRIPTION
Hi there, I just tried adding `scroll-to-hash-element` to a project (React 18, TypeScript 4.1) and had to make a few tweaks...

* Typescript error: ScrollToHashElement missing return-type
* A hash link clicked twice in a row fails to navigate the second time
* Window listeners are being added multiple times
* On first run the page scrolls smoothly to a hashlink. Default to "auto" behavior on first run.

Please feel free to edit / merge in the changes if you like them :)

Chichi.
